### PR TITLE
Add main executable

### DIFF
--- a/exe/project_templates
+++ b/exe/project_templates
@@ -1,0 +1,9 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# typed: strict
+
+require "project_templates"
+require "sorbet-runtime"
+
+app = ProjectTemplates::App.new
+app.run


### PR DESCRIPTION
With this change it is possible to run `bundle exec exe/project_templates` and have "hello" displayed. This wires up the application so that it is possible to actually do something useful.

Time to add documentation improvements.