### PR TITLE
Add config class

### DIFF
--- a/exe/project_templates
+++ b/exe/project_templates
@@ -5,5 +5,6 @@
 require "project_templates"
 require "sorbet-runtime"
 
-app = ProjectTemplates::App.new
+config = ProjectTemplates::Config.new(dry_run: true)
+app = ProjectTemplates::App.new(config)
 app.run

--- a/lib/project_templates.rb
+++ b/lib/project_templates.rb
@@ -4,6 +4,7 @@
 require "sorbet-runtime"
 
 require_relative "project_templates/app"
+require_relative "project_templates/config"
 require_relative "project_templates/version"
 
 module ProjectTemplates

--- a/lib/project_templates/app.rb
+++ b/lib/project_templates/app.rb
@@ -4,8 +4,20 @@
 require "sorbet-runtime"
 
 module ProjectTemplates
+  # This responsible for doing all the work of the application. Once
+  # configured you run the application and it'll run according to the
+  # configuration. Note that there is going to be a separate CLIApplication
+  # class that handles setting-up the application and running it. That CLI
+  # will handle command line argument parsing displaying help, etc. This is
+  # so that the App class can be used by a graphical interface or even a
+  # web-app in the future.
   class App
     extend T::Sig
+
+    sig { params(config: T.nilable(Config)).void }
+    def initialize(config = nil)
+      @config = config
+    end
 
     sig { void }
     # The main entry point of the application. Instantiate the application

--- a/lib/project_templates/config.rb
+++ b/lib/project_templates/config.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+# typed: strict
+
+require "sorbet-runtime"
+
+module ProjectTemplates
+  # Provides all of the unique configuration for the application. The
+  # attributes allow both getting and setting of configuration values so
+  # that a Configuration can be built "on the fly" Class methods to
+  # instantiate a configuration using defaults simplify getting a config
+  # ready to use.
+  class Config
+    extend T::Sig
+
+    sig { returns(T::Boolean) }
+    # When dry-run is true no changes to the file system will be made but
+    # all other steps will be completed. Access to the target path will be
+    # verified and all other compilation steps will complete.
+    attr_accessor :dry_run
+
+    # attr_reader :user_path, :project_path, :template_path, :target_path, :template_name, :target_name,
+    #             :user_variables, :project_variables
+
+    sig { params(dry_run: T::Boolean).void }
+    # Initialize a config by explicitly setting all of the values. If you
+    # don't want to set all values consider using one of the class methods
+    # instead.
+    def initialize(dry_run: false)
+      @dry_run = dry_run
+    end
+
+    alias dry_run? dry_run
+  end
+end

--- a/test/project_templates/test_app.rb
+++ b/test/project_templates/test_app.rb
@@ -13,6 +13,11 @@ class TestApp < MiniTest::Test
     assert_respond_to app, :run
   end
 
+  def test_it_can_be_initialized_with_a_config
+    config = nil
+    ProjectTemplates::App.new(config)
+  end
+
   def test_it_prints_hello
     assert_output(/Hello/) { app.run }
   end

--- a/test/project_templates/test_config.rb
+++ b/test/project_templates/test_config.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TestConfig < MiniTest::Test
+  attr_reader :config
+
+  def setup
+    @config = ProjectTemplates::Config.new
+  end
+
+  def test_initializes_dry_run_to_false_by_default
+    refute config.dry_run?
+  end
+
+  def test_it_initializes_dry_run
+    config = ProjectTemplates::Config.new(dry_run: true)
+    assert config.dry_run?
+  end
+
+  def test_has_a_dry_run_method
+    assert_respond_to config, :dry_run?
+    assert_respond_to config, :dry_run
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,5 +3,6 @@
 $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 
 require "minitest/autorun"
+require "minitest/mock"
 
 require "project_templates"

--- a/test/test_project_templates.rb
+++ b/test/test_project_templates.rb
@@ -10,4 +10,8 @@ class TestProjectTemplates < MiniTest::Test
   def test_it_has_an_app
     refute_nil ProjectTemplates::App
   end
+
+  def test_it_has_a_config
+    refute_nil ProjectTemplates::Config
+  end
 end


### PR DESCRIPTION
Working towards solving this:
https://github.com/cutehax0r/project_templates/issues/7

This PR adds a config class with a single `dry_run` attribute. It teaches the `App` class to expect configurations, and it modifies `exe/project_templates` to create a config that gets passed to `App` to make it easier to do some testing.

This is still a bit of a work in progress but it gives a place to hang other configuration methods. This is a good stop to stop and think about how initialization should happen. 

#### A bunch of initialize arguments
this could be done with `**args`, but I really like the type safety sorbet can provide. this list is probably going to be 10 items long which is **crumby**.

```ruby
class Config
  def initialize(template_path:, template_name:, target_path, user_variables:, project_variables…)
    @template_path = template_path
    @template_name = template_name
    …
  end
end
…

config = Config.new(
  template_path: "/foo/bar",
  template_name: "bing",
  target_path: "/bing/bang",
  …
)
```

the arguments will all be required so there will be some sort of class methods that do the heavy lifting with defaults:
```ruby
class Config
  def self.default
    new(
      template_path: "/foo/bar",
      template_name: "bing",
      target_path: "/bing/bang",
      …
    )
  end
class 
config = Config.default
```

This works and it's easy enough to follow. One thing I'd like is that this pattern can be used:
https://thoughtbot.com/blog/mygem-configure-block

```ruby
config = Config.default do |c|
  c.template_path = "/foo/bar"
  c.template_name = "bing"
  c.target_path = "/bing/bang"
end
```

This requires a bit of thought before continuing.