### PR TITLE
Add sorbet to gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,5 @@ source "https://rubygems.org"
 gemspec
 
 gem "rake", "~> 13.0"
+gem "sorbet", group: :development
+gem "sorbet-runtime"


### PR DESCRIPTION
This is part of an experiment to get Github Ci running. It's not installing sorbet despite the declaration in the gemspec. I'm trying to add it explicitly to see if that helps.

https://github.com/cutehax0r/project_templates/pull/10

There's a good chance this PR will be reverted.