### PR TITLE
Improve testing with `focus` and `pry`

### DIFF
--- a/project_templates.gemspec
+++ b/project_templates.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "github-markup"
   s.add_development_dependency "minitest"
+  s.add_development_dependency "minitest-focus"
   s.add_development_dependency "pry"
   s.add_development_dependency "redcarpet"
   s.add_development_dependency "rubocop"

--- a/test/project_templates/test_app.rb
+++ b/test/project_templates/test_app.rb
@@ -14,7 +14,7 @@ class TestApp < MiniTest::Test
   end
 
   def test_it_can_be_initialized_with_a_config
-    config = nil
+    config = MiniTest::Mock.new(ProjectTemplates::Config.new)
     ProjectTemplates::App.new(config)
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,5 +4,7 @@ $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 
 require "minitest/autorun"
 require "minitest/mock"
+require "minitest/focus"
+require "pry"
 
 require "project_templates"


### PR DESCRIPTION
This adds some improvements to the test/debut cycle.

  1. It adds minitest-focus which allows you to write "focus" above the definition of a test and then only that test will run. For more details read https://github.com/seattlerb/minitest-focus

  2. Adds pry to the test helper. This allows you to add `binding.pry` to a test and be dumped into a debugger when you reach that point.

While we're here we also use the MiniTest::Mock library that was added in 55c993b2 to mock a config rather than passing an explicit nil. Strictly speaking that isn't required for this but it does kinda glue together all these improvements that are being made.