### PR TITLE
Continue building config + style updates

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,6 +16,12 @@ Style/StringLiterals:
 Style/StringLiteralsInInterpolation:
   Enabled: false
 
+Style/TrailingCommaInArrayLiteral:
+  EnforcedStyleForMultiline: consistent_comma
+
+Style/TrailingCommaInHashLiteral:
+  EnforcedStyleForMultiline: consistent_comma
+
 Layout/EmptyLineAfterMagicComment:
   Enabled: false
 

--- a/lib/project_templates/config.rb
+++ b/lib/project_templates/config.rb
@@ -12,21 +12,49 @@ module ProjectTemplates
   class Config
     extend T::Sig
 
+    DEFAULT_TEMPLATE_PATH = T.let(Pathname.new("~").expand_path, Pathname)
+    DEFAULT_PROJECT_PATH = T.let(Pathname.new("~").expand_path, Pathname)
+    DEFAULT_TARGET_PATH = T.let(Pathname.new(Dir.pwd).expand_path, Pathname)
+
     sig { returns(T::Boolean) }
     # When dry-run is true no changes to the file system will be made but
     # all other steps will be completed. Access to the target path will be
     # verified and all other compilation steps will complete.
     attr_accessor :dry_run
 
-    # attr_reader :user_path, :project_path, :template_path, :target_path, :template_name, :target_name,
-    #             :user_variables, :project_variables
+    sig { returns(Pathname) }
+    # The path where template projects are located. This is the path where
+    # the project_path is expected to be
+    attr_accessor :template_path
 
-    sig { params(dry_run: T::Boolean).void }
+    sig { returns(Pathname) }
+    # The path which will be used as the "source" for creating the new project
+    # by default this would be located within #template_path and is computed by
+    # joining project_name to template_path.
+    attr_accessor :project_path
+
+    sig { returns(Pathname) }
+    # The path which will be created by copying files from the project_path to
+    # this location. The is computed by appending target_name to the current
+    # working directory
+    attr_accessor :target_path
+
+    # TODO: attr_accessor :template_name, :target_name, :user_variables, :project_variables
+
+    sig { params(dry_run: T::Boolean, template_path: Pathname, project_path: Pathname, target_path: Pathname).void }
     # Initialize a config by explicitly setting all of the values. If you
     # don't want to set all values consider using one of the class methods
     # instead.
-    def initialize(dry_run: false)
+    def initialize(
+      dry_run: false,
+      template_path: DEFAULT_TEMPLATE_PATH,
+      project_path: DEFAULT_PROJECT_PATH,
+      target_path: DEFAULT_TARGET_PATH
+    )
       @dry_run = dry_run
+      @template_path = T.let(template_path, Pathname)
+      @project_path = T.let(project_path, Pathname)
+      @target_path = T.let(target_path, Pathname)
     end
 
     alias dry_run? dry_run

--- a/project_templates.gemspec
+++ b/project_templates.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
     "--main", "README.md",
     "--line-numbers",
     "--inline-source",
-    "--quiet"
+    "--quiet",
   ]
 
   s.add_development_dependency "github-markup"

--- a/test/project_templates/test_app.rb
+++ b/test/project_templates/test_app.rb
@@ -9,16 +9,16 @@ class TestApp < MiniTest::Test
     @app = ProjectTemplates::App.new
   end
 
-  def test_it_can_be_run
-    assert_respond_to app, :run
+  def test_can_be_run
+    assert_respond_to(app, :run)
   end
 
-  def test_it_can_be_initialized_with_a_config
+  def test_can_be_initialized_with_a_config
     config = MiniTest::Mock.new(ProjectTemplates::Config.new)
     ProjectTemplates::App.new(config)
   end
 
-  def test_it_prints_hello
+  def test_prints_hello
     assert_output(/Hello/) { app.run }
   end
 end

--- a/test/project_templates/test_config.rb
+++ b/test/project_templates/test_config.rb
@@ -3,23 +3,43 @@
 require "test_helper"
 
 class TestConfig < MiniTest::Test
-  attr_reader :config
+  extend HasAttributeHelper
+
+  attr_reader :config, :class_under_test
 
   def setup
-    @config = ProjectTemplates::Config.new
+    @class_under_test = ProjectTemplates::Config
+    @config = class_under_test.new
   end
 
-  def test_initializes_dry_run_to_false_by_default
-    refute config.dry_run?
+  test_has_attribute(:config, :template_path, readable: true, writable: true)
+  test_has_attribute(:config, :project_path, readable: true, writable: true)
+  test_has_attribute(:config, :target_path, readable: true, writable: true)
+  test_has_attribute(:config, :dry_run, readable: true, writable: true, interrogatable: true)
+
+  def test_defines_default_constants
+    assert_equal(Pathname.new("~").expand_path, class_under_test::DEFAULT_TEMPLATE_PATH)
+    assert_equal(Pathname.new("~").expand_path, class_under_test::DEFAULT_PROJECT_PATH)
+    assert_equal(Pathname.new(Dir.pwd).expand_path, class_under_test::DEFAULT_TARGET_PATH)
   end
 
-  def test_it_initializes_dry_run
-    config = ProjectTemplates::Config.new(dry_run: true)
-    assert config.dry_run?
+  def test_initialize_uses_defaults
+    refute(config.dry_run?)
+    assert_equal(class_under_test::DEFAULT_TEMPLATE_PATH, config.template_path)
+    assert_equal(class_under_test::DEFAULT_PROJECT_PATH, config.project_path)
+    assert_equal(class_under_test::DEFAULT_TARGET_PATH, config.target_path)
   end
 
-  def test_has_a_dry_run_method
-    assert_respond_to config, :dry_run?
-    assert_respond_to config, :dry_run
+  def test_initialize_can_be_provided_all_arguments
+    args = {
+      dry_run: true,
+      template_path: Pathname.new("/").expand_path,
+      project_path: Pathname.new("/").expand_path,
+      target_path: Pathname.new("/").expand_path,
+    }
+    inited_config = class_under_test.new(**args)
+    args.each do |argument, expected_value|
+      assert_equal expected_value, inited_config.send(argument)
+    end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -8,3 +8,30 @@ require "minitest/focus"
 require "pry"
 
 require "project_templates"
+
+module HasAttributeHelper
+  # A helper to ensure that a class has an attribute defined.
+  #   * `instance` is the symbol for a method that will return an instance
+  #      to assert on.
+  #   * `attribute` is the symbol for the name of the attribute checked
+  #   * `readable` ensures that the attribute is readable; which is to say
+  #      that #attribute is defined.
+  #   * `writable` ensures that the attribute is writable; which is to say
+  #      that #attribute= is defined.
+  #   * `interrogatable` ensures that the attribute is boolean-querable;
+  #      which is to say that #attribute? is defined.
+  # this tests only creates positive assertions: if `readable` is nil or
+  # false then no assertion is created. a "refute_respond_to" assertion
+  # will not be generated.
+  def test_has_attribute(instance, attribute, readable: false, writable: false, interrogatable: false)
+    attribute_kind = { readable:, writable:, interrogatable: }.select{_2}.keys
+    test_name = "test_#{attribute}_is_a_#{attribute_kind.join('_')}"
+
+    define_method(test_name.to_sym) do
+      captured_instance = send(instance)
+      assert_respond_to(captured_instance, attribute) if readable
+      assert_respond_to(captured_instance, "#{attribute}=".to_sym) if writable
+      assert_respond_to(captured_instance, "#{attribute}?".to_sym) if interrogatable
+    end
+  end
+end

--- a/test/test_project_templates.rb
+++ b/test/test_project_templates.rb
@@ -4,14 +4,14 @@ require "test_helper"
 
 class TestProjectTemplates < MiniTest::Test
   def test_it_has_a_version
-    refute_nil ProjectTemplates::VERSION
+    refute_nil(ProjectTemplates::VERSION)
   end
 
   def test_it_has_an_app
-    refute_nil ProjectTemplates::App
+    refute_nil(ProjectTemplates::App)
   end
 
   def test_it_has_a_config
-    refute_nil ProjectTemplates::Config
+    refute_nil(ProjectTemplates::Config)
   end
 end


### PR DESCRIPTION
### Adds a new test helper
`has_attribute_helper` makes it easy to test that attribute accessors, readers, writers, and `?` methods are defined.
```ruby
class TestFoo < Minitest::Test
  extend HasAttributeHelper
  attr_reader :foo
  def setup
    @foo = Foo.new
  end
  …
  test_has_attribute(:foo, :bar_attr, readable: true, writable: true, interrogatable: true)
  …
end
```
This would ensure `Foo` has attribute `#bar_attr`, `#bar_attr=` and `#bar_attr?` defined.

### Adds config

* Defines a few default constants for paths. These are mostly placeholders and will likely go away.
* `DEFAULT_TARGET_PATH` the place where files will be written
* `DEFAULT_PROJECT_PATH` the place that will be used as the "source" template
* `DEFAULT_TEMPLATE_PATH` the place where `PROJECT_PATH` should be found

Then some attributes for `target_path`, `template_path`, and `project_path` are defined, and `initialize()` learns to expect those attributes when creating a new `Config`

### EXTRA STUFF: This sneaks in a couple of style changes.
1. Rubocop rules to enforce "[consistent commas](https://docs.rubocop.org/rubocop/cops_style.html#styletrailingcommainarrayliteral)" in multi-line hashes and arrays:
```ruby
dict = { a: 1, b: 2 }
dict = {
  a: 1,
  b: 2,
}
```
2. Some test style consistency: dropping "it" from test descriptions, adding brackets around assertion arguments

