### PR TITLE
Config gets working_path, project_name, and target_name + rubocop test updates

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,20 @@ AllCops:
   SuggestExtensions: false
   TargetRubyVersion: 3.1
 
+Metrics/AbcSize:
+  Exclude:
+    - "test/**/*"
+
+Metrics/MethodLength:
+  Exclude:
+    - "test/**/*"
+
+Layout/EmptyLineAfterMagicComment:
+  Enabled: false
+
+Layout/LineLength:
+  Max: 120
+
 Style/Documentation:
   Enabled: false
 
@@ -22,8 +36,3 @@ Style/TrailingCommaInArrayLiteral:
 Style/TrailingCommaInHashLiteral:
   EnforcedStyleForMultiline: consistent_comma
 
-Layout/EmptyLineAfterMagicComment:
-  Enabled: false
-
-Layout/LineLength:
-  Max: 120

--- a/lib/project_templates/config.rb
+++ b/lib/project_templates/config.rb
@@ -15,12 +15,16 @@ module ProjectTemplates
     DEFAULT_TEMPLATE_PATH = T.let(Pathname.new("~").expand_path, Pathname)
     DEFAULT_PROJECT_PATH = T.let(Pathname.new("~").expand_path, Pathname)
     DEFAULT_TARGET_PATH = T.let(Pathname.new(Dir.pwd).expand_path, Pathname)
+    DEFAULT_WORKING_PATH = T.let(Pathname.new(Dir.pwd).expand_path, Pathname)
+    DEFAULT_TARGET_NAME = T.let("target", String)
+    DEFAULT_PROJECT_NAME = T.let("project", String)
 
     sig { returns(T::Boolean) }
     # When dry-run is true no changes to the file system will be made but
     # all other steps will be completed. Access to the target path will be
     # verified and all other compilation steps will complete.
     attr_accessor :dry_run
+    alias dry_run? dry_run
 
     sig { returns(Pathname) }
     # The path where template projects are located. This is the path where
@@ -39,24 +43,54 @@ module ProjectTemplates
     # working directory
     attr_accessor :target_path
 
-    # TODO: attr_accessor :template_name, :target_name, :user_variables, :project_variables
+    sig { returns(Pathname) }
+    # The working directory, where the new project will be created. Defaults to
+    # the current working directory.
+    attr_accessor :working_path
 
-    sig { params(dry_run: T::Boolean, template_path: Pathname, project_path: Pathname, target_path: Pathname).void }
+    sig { returns(String) }
+    # The name of the target. Appended to the end of working directory to form
+    # target_path.
+    attr_accessor :target_name
+
+    sig { returns(String) }
+    # the name of the project directory to use as a source. Appended to
+    # template_path to produce project_path
+    attr_accessor :project_name
+
+    # TODO: attr_accessor  :working_path, :user_variables, :project_variables
+
+    sig do
+      params(
+        dry_run: T::Boolean,
+        template_path: Pathname,
+        project_path: Pathname,
+        target_path: Pathname,
+        working_path: Pathname,
+        project_name: String,
+        target_name: String
+      ).void
+    end
     # Initialize a config by explicitly setting all of the values. If you
     # don't want to set all values consider using one of the class methods
-    # instead.
-    def initialize(
+    # instead. Paths and Variables should probably become objects but for
+    # now the rubocop rule about param lists will be ignored
+    def initialize( # rubocop:disable Metrics/ParameterLists
       dry_run: false,
       template_path: DEFAULT_TEMPLATE_PATH,
       project_path: DEFAULT_PROJECT_PATH,
-      target_path: DEFAULT_TARGET_PATH
+      target_path: DEFAULT_TARGET_PATH,
+      working_path: DEFAULT_TARGET_PATH,
+      project_name: DEFAULT_PROJECT_NAME,
+      target_name: DEFAULT_TARGET_NAME
     )
       @dry_run = dry_run
-      @template_path = T.let(template_path, Pathname)
-      @project_path = T.let(project_path, Pathname)
-      @target_path = T.let(target_path, Pathname)
+      @template_path = template_path
+      @project_path = project_path
+      @target_path = target_path
+      @working_path = working_path
+      @project_name = project_name
+      @target_name = target_name
     end
-
-    alias dry_run? dry_run
   end
 end

--- a/test/project_templates/test_config.rb
+++ b/test/project_templates/test_config.rb
@@ -12,15 +12,21 @@ class TestConfig < MiniTest::Test
     @config = class_under_test.new
   end
 
+  test_has_attribute(:config, :dry_run, readable: true, writable: true, interrogatable: true)
   test_has_attribute(:config, :template_path, readable: true, writable: true)
   test_has_attribute(:config, :project_path, readable: true, writable: true)
   test_has_attribute(:config, :target_path, readable: true, writable: true)
-  test_has_attribute(:config, :dry_run, readable: true, writable: true, interrogatable: true)
+  test_has_attribute(:config, :working_path, readable: true, writable: true)
+  test_has_attribute(:config, :project_name, readable: true, writable: true)
+  test_has_attribute(:config, :target_name, readable: true, writable: true)
 
   def test_defines_default_constants
     assert_equal(Pathname.new("~").expand_path, class_under_test::DEFAULT_TEMPLATE_PATH)
     assert_equal(Pathname.new("~").expand_path, class_under_test::DEFAULT_PROJECT_PATH)
     assert_equal(Pathname.new(Dir.pwd).expand_path, class_under_test::DEFAULT_TARGET_PATH)
+    assert_equal(Pathname.new(Dir.pwd).expand_path, class_under_test::DEFAULT_WORKING_PATH)
+    assert_equal("target", class_under_test::DEFAULT_TARGET_NAME)
+    assert_equal("project", class_under_test::DEFAULT_PROJECT_NAME)
   end
 
   def test_initialize_uses_defaults
@@ -36,6 +42,9 @@ class TestConfig < MiniTest::Test
       template_path: Pathname.new("/").expand_path,
       project_path: Pathname.new("/").expand_path,
       target_path: Pathname.new("/").expand_path,
+      working_path: Pathname.new("/").expand_path,
+      project_name: "new_project",
+      target_name: "some_target",
     }
     inited_config = class_under_test.new(**args)
     args.each do |argument, expected_value|


### PR DESCRIPTION
Additional effort for https://github.com/cutehax0r/project_templates/issues/7

### Add working_path, target_name, and  project_name to config
###
Continuing on the the building of the Config object.

* `working_path` is defined as an attribute. This is the location
    where the output of the template will be written. It will be
    prefixed to `target_name` to produce `target_path`.

* `target_name` was added: it's the name of the new directory to
  create inside of `working_path`.

* `project_name` was added: it's the name of the project to use as the
  source. It's appended to `template_path` to produce `project_path`

Default constants for the above are defined. Again, just placeholders
that will likely change.

Alias for `dry_run?` moved closer to the `dry_run` accessor declaration
just because it makes sense.

the `initialize()` method is growing pretty heavy on arguments. I'm
disabling the warning cop for now. Longer term it seems like a `paths`
variable to hold `template`, `working`, `target`, and `project` might be
a good idea.

A similar need will arise for the "dictionaries" of variables that will
be provided for command line, project, and global defaults.

`paths`, `variables`, `target_name`, `dry_run` are probably all we
really want for `the `initialize` method.

### EXTRA STUFF: Rubocop updates

Allow test methods to break some rules. Tests get to do multiple
assignments because it makes reading them easier, plus assertions
sometimes need to happen on multiple bits of data in a single test. The
ABC cop is disabled for test/**/*

This is also the reason the line length for methods is disabled:
sometimes a test really should do a lot of stuff.

The rubocop file was also reordered to be alphabetical.