### PR TITLE
Define variables dictionary

### DIFF
--- a/lib/project_templates.rb
+++ b/lib/project_templates.rb
@@ -5,6 +5,7 @@ require "sorbet-runtime"
 
 require_relative "project_templates/app"
 require_relative "project_templates/config"
+require_relative "project_templates/dictionary"
 require_relative "project_templates/version"
 
 module ProjectTemplates

--- a/lib/project_templates/config.rb
+++ b/lib/project_templates/config.rb
@@ -58,7 +58,7 @@ module ProjectTemplates
     # template_path to produce project_path
     attr_accessor :project_name
 
-    # TODO: attr_accessor  :working_path, :user_variables, :project_variables
+    # TODO: attr_accessor  :user_variables, :project_variables, :run_variables
 
     sig do
       params(

--- a/lib/project_templates/dictionary.rb
+++ b/lib/project_templates/dictionary.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+# typed: strict
+
+require "sorbet-runtime"
+
+module ProjectTemplates
+  class Dictionary
+    extend T::Sig
+
+    sig { void }
+    def initialize; end
+  end
+end

--- a/test/project_templates/test_dictionary.rb
+++ b/test/project_templates/test_dictionary.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TestDictionary < Minitest::Test
+end

--- a/test/test_project_templates.rb
+++ b/test/test_project_templates.rb
@@ -3,15 +3,19 @@
 require "test_helper"
 
 class TestProjectTemplates < MiniTest::Test
-  def test_it_has_a_version
-    refute_nil(ProjectTemplates::VERSION)
-  end
-
-  def test_it_has_an_app
+  def test_has_an_app
     refute_nil(ProjectTemplates::App)
   end
 
-  def test_it_has_a_config
+  def test_has_a_config
     refute_nil(ProjectTemplates::Config)
+  end
+
+  def test_has_a_dictionary
+    refute_nil(ProjectTemplates::Dictionary)
+  end
+
+  def test_has_a_version
+    refute_nil(ProjectTemplates::VERSION)
   end
 end


### PR DESCRIPTION
Continue work on https://github.com/cutehax0r/project_templates/issues/7

### Create Dictionary Stub
The `Dictionary` will hold variables. These may be from a YAML file,
JSON, or just "explicitly set" with some kind of a `config {}` block.
I'm not totally sure what this looks like.

There will be instances of dictionaries for "global" variables from
~/.config/project_templates/variables.yaml, "project" variables from
~/.local/share/project_templates/project/foo_project/variables.yaml, and
one to wrap arguments provided as command line arguments.

All of these dictionaries will be "wrapped" in a variables object which
will be responsible for enforcing the override priorities: command line
> project > global.

Maybe this will will just be a glorified openstuct.  The goal is to have
an interface that can be navigated with "dots" in templates.
`foo.bar.baz` rather than `config[:foo][:bar][:baz]`.