### PR TITLE
Add class_under_test helper

### DIFF
--- a/test/project_templates/test_app.rb
+++ b/test/project_templates/test_app.rb
@@ -3,10 +3,11 @@
 require "test_helper"
 
 class TestApp < MiniTest::Test
+  include ClassUnderTest
   attr_reader :app
 
   def setup
-    @app = ProjectTemplates::App.new
+    @app = class_under_test.new
   end
 
   def test_can_be_run
@@ -15,7 +16,7 @@ class TestApp < MiniTest::Test
 
   def test_can_be_initialized_with_a_config
     config = MiniTest::Mock.new(ProjectTemplates::Config.new)
-    ProjectTemplates::App.new(config)
+    class_under_test.new(config)
   end
 
   def test_prints_hello

--- a/test/project_templates/test_config.rb
+++ b/test/project_templates/test_config.rb
@@ -4,11 +4,11 @@ require "test_helper"
 
 class TestConfig < MiniTest::Test
   extend HasAttributeHelper
+  include ClassUnderTest
 
-  attr_reader :config, :class_under_test
+  attr_reader :config
 
   def setup
-    @class_under_test = ProjectTemplates::Config
     @config = class_under_test.new
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -9,6 +9,22 @@ require "pry"
 
 require "project_templates"
 
+module ClassUnderTest
+  # This is a helper that returns the name of the class. This feature is
+  # implemented pretty naively for the sake of readability. It maps
+  # `TestFoobar` to `ProjectTemplates::Foobar`. At least for the moment a more
+  # complicated helper is not required, just "include it into your test file"
+  # to make it available.
+  def class_under_test
+    return @class_under_test if defined?(@class_under_test)
+
+    namespace = "ProjectTemplates"
+    test_name = self.class.to_s
+    full_class_name = [namespace, test_name[4..]].join("::")
+    @class_under_test = Kernel.const_get(full_class_name)
+  end
+end
+
 module HasAttributeHelper
   # A helper to ensure that a class has an attribute defined.
   #   * `instance` is the symbol for a method that will return an instance


### PR DESCRIPTION
### Add `ClassUnderTest` helper to `test_helper.rb`

There was already a bit of a naive version of this method defined in the
`TestConfig` class by explicitly declaring an instance variable and
adding an attr_reader. Instead of doing that in every class we've got a
simple helper that can be 'included' into a test file.

The implementation is trivial: map `TestFoo` to `ProjectTemplates::Foo`.
It doesn't try to do any clever path lookup or walking of the object
hierarchy: just straight string manipulation. It won't be foolproof, but
it's simple enough to understand and makes the tests a lot easier to
read and write.


Use it by:
```ruby

# frozen_string_literal: true

require "test_helper"

class TestFoo < Minitest::Test
  include ClassUnderTest

  attr_reader: foo

  def setup
    @foo = class_under_test.new
  end

  def test_instantiation
    assert(foo)
  end

  def test_has_const_bar_equal_to_bingbangbong
    assert_equal("bingbangbong", class_under_test::BAR)
  end
end
```

### Extra stuff
* Old crufty version in `TestConfig` removed.
* Tests use the new helper
