### PR TITLE
Implement Dicionary parsing

### DIFF
--- a/lib/project_templates/dictionary.rb
+++ b/lib/project_templates/dictionary.rb
@@ -1,13 +1,67 @@
 # frozen_string_literal: true
 # typed: strict
 
+require "delegate"
+require "json"
+require "yaml"
 require "sorbet-runtime"
 
 module ProjectTemplates
-  class Dictionary
-    extend T::Sig
+  # Dictionary wraps a set of nested key-value pairs loaded form some source.
+  # The keys loaded form the source will be methods on the dictionary which will
+  # return their values. In the case of nested key/value pairs, all of the values
+  # are recursively turned into methods.
+  #
+  # in the event you really want an ordinary Hash instead of an openstruct you
+  # can always call `.table` on a key to get it's value as a hash with
+  # symbolized keys.
+  class Dictionary < SimpleDelegator
+    # New is made private to ensure only a valid `OpenStruct` is passed to the class
+    # constructor and delegation works as expected.
+    private_class_method :new
 
-    sig { void }
-    def initialize; end
+    class << self
+      extend T::Sig
+
+      sig { params(input: T.any(String, OpenStruct, T::Hash[T.untyped, T.untyped])).returns(Dictionary) }
+      # The valid inputs to load variables are:
+      #   * `Hash`: a standard ruby dictionary of nested key_value pairs. All keys
+      #      must respond to `to_sym` or loading will fail.
+      #   * `OpenStruct` containing nested key/value pairs.
+      #   * `String` containing YAML,
+      #   * `String` containing JSON.
+      # All inputs will be recursively parsed into `OpenStructs`. Any keys in the
+      # input will then become methods on the `Dictionary`.
+      def load(input)
+        case input
+        when OpenStruct then load_string(JSON.dump(input.table))
+        when Hash then new(OpenStruct.new(input))
+        when String then load_string(input)
+        else T.absurd(input)
+        end
+      end
+
+      alias parse load
+
+      private
+
+      sig { params(input: String).returns(Dictionary) }
+      # You can pass a string and so long as it passes through the YAML and JSON
+      # parser to produce an `OpenStruct` then everything is fine. Some valid JSON
+      # and YAML will not produce a dictionary. E.g. "[1, 2, 3]" is valid for
+      # both JSON and YAML but parses to an `Array`. Invalid JSON will also cause
+      # an error. If a valid `OpenStruct` cannot be formed `ArgumentError` is raised.
+      def load_string(input)
+        yaml_input = YAML.safe_load(input)
+        json_input = yaml_input.to_json
+        openstruct_input = JSON.parse(json_input, object_class: OpenStruct)
+
+        raise(ArgumentError, "Input did not produce a dictionary") unless openstruct_input.is_a?(OpenStruct)
+
+        new(openstruct_input)
+      rescue JSON::JSONError, Psych::Exception => e
+        raise(ArgumentError, e.to_s)
+      end
+    end
   end
 end

--- a/test/project_templates/test_dictionary.rb
+++ b/test/project_templates/test_dictionary.rb
@@ -3,4 +3,84 @@
 require "test_helper"
 
 class TestDictionary < Minitest::Test
+  include ClassUnderTest
+
+  def test_initializes_with_yaml
+    input = <<~YAML
+      ---
+      foo: 123
+    YAML
+    dict = class_under_test.load(input)
+    assert_equal 123, dict.foo
+  end
+
+  def test_loads_with_json
+    input = '{"foo": 123}'
+    dict = class_under_test.load(input)
+    assert_equal 123, dict.foo
+  end
+
+  def test_loads_with_ruby_hash
+    input = { foo: 123 }
+    dict = class_under_test.load(input)
+    assert_equal 123, dict.foo
+  end
+
+  def test_loads_with_openstruct
+    input = OpenStruct.new(foo: 123)
+    dict = class_under_test.load(input)
+    assert_equal 123, dict.foo
+  end
+
+  def test_parse_is_another_spelling_of_load
+    input = { foo: 123 }
+    dict = class_under_test.parse(input)
+    assert_equal 123, dict.foo
+  end
+
+  def test_nested_keys_in_yaml
+    input = <<~YAML
+      ---
+      foo: 123
+      bar:
+        bing: 456
+        bong: 789
+    YAML
+    dict = class_under_test.load(input)
+    assert_equal(123, dict.foo)
+    assert_equal(456, dict.bar.bing)
+    assert_equal(789, dict.bar.bong)
+    assert_raises(NoMethodError) { dict.baz }
+  end
+
+  def test_nested_keys_in_openstruct
+    input = OpenStruct.new(foo: 123, bar: { bing: 456, bong: 789 })
+    dict = class_under_test.load(input)
+    assert_equal(123, dict.foo)
+    assert_equal(456, dict.bar.bing)
+    assert_equal(789, dict.bar.bong)
+    assert_raises(NoMethodError) { dict.baz }
+  end
+
+  def test_new_is_private
+    assert_raises(NoMethodError) { class_under_test.new }
+  end
+
+  def test_throws_argument_error_on_yaml_that_doesnt_make_a_hash
+    input = <<~YAML
+      ---
+      - foo
+    YAML
+    assert_raises(ArgumentError) { class_under_test.load(input) }
+  end
+
+  def test_throws_argument_error_on_json_that_doesnt_make_a_hash
+    input = "[1, 2, 3]"
+    assert_raises(ArgumentError) { class_under_test.load(input) }
+  end
+
+  def test_throws_argument_error_on_invalid_json
+    input = "{invalid"
+    assert_raises(ArgumentError) { class_under_test.load(input) }
+  end
 end


### PR DESCRIPTION
Continue work on https://github.com/cutehax0r/project_templates/issues/7

### Makes `Dictionary` instantiable and useful.

A Dictionary class now exists. It can be instantiated with
  * A ruby hash
  * An OpenStruct
  * A string of JSON
  * A string of YAML
Failure to parse the input will raise argument error.

A Dictionary instance delegates all method calls to the struct that it
was instantiated with: each of the keys becomes a method call that
returns its corresponding value. This Key-to-method-call trick is
performed recursively.

```ruby
dict = Dictionary.load({a: { b: 1}, c: 2 })
dict.a.b # => 1
dict.c # => 2
dict.d # raises NoMethodError
```

This is intended to wrap input loaded from files and also arguments
passed as command line attributes.