### PR TITLE
Handle "invalid" ruby hash passed to dict

### DIFF
--- a/lib/project_templates/dictionary.rb
+++ b/lib/project_templates/dictionary.rb
@@ -39,6 +39,8 @@ module ProjectTemplates
         when String then load_string(input)
         else T.absurd(input)
         end
+      rescue NoMethodError => e
+        raise(ArgumentError, e.to_s)
       end
 
       alias parse load

--- a/test/project_templates/test_dictionary.rb
+++ b/test/project_templates/test_dictionary.rb
@@ -83,4 +83,9 @@ class TestDictionary < Minitest::Test
     input = "{invalid"
     assert_raises(ArgumentError) { class_under_test.load(input) }
   end
+
+  def test_throws_argument_error_on_ruby_hash_that_doesnt_make_openstruct
+    input = { [1] => "invalid key" }
+    assert_raises(ArgumentError) { class_under_test.load(input) }
+  end
 end


### PR DESCRIPTION
part of https://github.com/cutehax0r/project_templates/issues/7

Example:
```ruby
Dictionary.new({ [1, 2] => "crashes because array can't be symbolized"})
# raises `NoMethodError` for call to `to_sym` on the `key`.
```
This change raises `ArgumentError` instead.

### Better error handling when parsing 'invalid' ruby hash

In order to create a Dictionary from a ruby hash all keys must be
symbolizable. This is because a dictionary uses keys to define methods
(or more precisely to delegate methods to an openstruct). If Keys can't
be symbolized method naming all falls apart.

This gets handled during the `load` phase but the error is confusing:
`NoMethodError` for `to_sym` on a hash key that can't be symbolized.

This swallows that error and bubbles it up as an ArgumentError which is
more consistent with the rest of the interface.