### PR TITLE
Wire Dictionaries into Config

### DIFF
--- a/lib/project_templates.rb
+++ b/lib/project_templates.rb
@@ -4,8 +4,8 @@
 require "sorbet-runtime"
 
 require_relative "project_templates/app"
-require_relative "project_templates/config"
 require_relative "project_templates/dictionary"
+require_relative "project_templates/config"
 require_relative "project_templates/version"
 
 module ProjectTemplates

--- a/lib/project_templates/config.rb
+++ b/lib/project_templates/config.rb
@@ -18,6 +18,7 @@ module ProjectTemplates
     DEFAULT_WORKING_PATH = T.let(Pathname.new(Dir.pwd).expand_path, Pathname)
     DEFAULT_TARGET_NAME = T.let("target", String)
     DEFAULT_PROJECT_NAME = T.let("project", String)
+    DEFAULT_DICTIONARY = T.let(Dictionary.load({}), Dictionary)
 
     sig { returns(T::Boolean) }
     # When dry-run is true no changes to the file system will be made but
@@ -59,6 +60,24 @@ module ProjectTemplates
     attr_accessor :project_name
 
     # TODO: attr_accessor  :user_variables, :project_variables, :run_variables
+    sig { returns(Dictionary) }
+    # Global variables are read from a configuration file and will override
+    # project variables when a conflict occurs. Global variables can in turn be
+    # overridden by variables provided at 'run'.
+    attr_accessor :global_variables
+
+    sig { returns(Dictionary) }
+    # These are variables defined within the project template. They are the
+    # lowest level of priority so that you can override variables (e.g. email,
+    # copyright holder) by defining them globally once instead of needing to
+    # pass overrides on every invocation as command line arguments.
+    attr_accessor :project_variables
+
+    sig { returns(Dictionary) }
+    # Run variables are the most-specific variables. They override variables
+    # defined globally which have in turn overriden variables provided by a
+    # project.
+    attr_accessor :run_variables
 
     sig do
       params(
@@ -68,7 +87,10 @@ module ProjectTemplates
         target_path: Pathname,
         working_path: Pathname,
         project_name: String,
-        target_name: String
+        target_name: String,
+        project_variables: Dictionary,
+        global_variables: Dictionary,
+        run_variables: Dictionary
       ).void
     end
     # Initialize a config by explicitly setting all of the values. If you
@@ -82,7 +104,10 @@ module ProjectTemplates
       target_path: DEFAULT_TARGET_PATH,
       working_path: DEFAULT_TARGET_PATH,
       project_name: DEFAULT_PROJECT_NAME,
-      target_name: DEFAULT_TARGET_NAME
+      target_name: DEFAULT_TARGET_NAME,
+      project_variables: DEFAULT_DICTIONARY,
+      global_variables: DEFAULT_DICTIONARY,
+      run_variables: DEFAULT_DICTIONARY
     )
       @dry_run = dry_run
       @template_path = template_path
@@ -91,6 +116,9 @@ module ProjectTemplates
       @working_path = working_path
       @project_name = project_name
       @target_name = target_name
+      @project_variables = project_variables
+      @global_variables = global_variables
+      @run_variables = run_variables
     end
   end
 end

--- a/test/project_templates/test_config.rb
+++ b/test/project_templates/test_config.rb
@@ -19,6 +19,9 @@ class TestConfig < MiniTest::Test
   test_has_attribute(:config, :working_path, readable: true, writable: true)
   test_has_attribute(:config, :project_name, readable: true, writable: true)
   test_has_attribute(:config, :target_name, readable: true, writable: true)
+  test_has_attribute(:config, :project_variables, readable: true, writable: true)
+  test_has_attribute(:config, :global_variables, readable: true, writable: true)
+  test_has_attribute(:config, :run_variables, readable: true, writable: true)
 
   def test_defines_default_constants
     assert_equal(Pathname.new("~").expand_path, class_under_test::DEFAULT_TEMPLATE_PATH)
@@ -27,6 +30,8 @@ class TestConfig < MiniTest::Test
     assert_equal(Pathname.new(Dir.pwd).expand_path, class_under_test::DEFAULT_WORKING_PATH)
     assert_equal("target", class_under_test::DEFAULT_TARGET_NAME)
     assert_equal("project", class_under_test::DEFAULT_PROJECT_NAME)
+    assert_instance_of(ProjectTemplates::Dictionary, class_under_test::DEFAULT_DICTIONARY)
+    assert_predicate(class_under_test::DEFAULT_DICTIONARY.table, :empty?)
   end
 
   def test_initialize_uses_defaults
@@ -34,6 +39,12 @@ class TestConfig < MiniTest::Test
     assert_equal(class_under_test::DEFAULT_TEMPLATE_PATH, config.template_path)
     assert_equal(class_under_test::DEFAULT_PROJECT_PATH, config.project_path)
     assert_equal(class_under_test::DEFAULT_TARGET_PATH, config.target_path)
+    assert_equal(class_under_test::DEFAULT_WORKING_PATH, config.working_path)
+    assert_equal("project", config.project_name)
+    assert_equal("target", config.target_name)
+    assert_equal(class_under_test::DEFAULT_DICTIONARY, config.project_variables)
+    assert_equal(class_under_test::DEFAULT_DICTIONARY, config.global_variables)
+    assert_equal(class_under_test::DEFAULT_DICTIONARY, config.run_variables)
   end
 
   def test_initialize_can_be_provided_all_arguments
@@ -45,6 +56,9 @@ class TestConfig < MiniTest::Test
       working_path: Pathname.new("/").expand_path,
       project_name: "new_project",
       target_name: "some_target",
+      project_variables: ProjectTemplates::Dictionary.load({ a: 1 }),
+      global_variables: ProjectTemplates::Dictionary.load({ b: 2 }),
+      run_variables: ProjectTemplates::Dictionary.load({ c: 3 }),
     }
     inited_config = class_under_test.new(**args)
     args.each do |argument, expected_value|


### PR DESCRIPTION
The config object now knows about global, project, and run variables. It
can expose these to the application which can use them to populate
templates.

The default values that are fed into dictionaries aren't very useful.
The next step is to modify the executable to "configure" the Config by
loading dictionaries and also setting things like the paths and names
appropriate.