### PR TITLE
Rubocop tweak - array element indentation consistency

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,6 +17,9 @@ Metrics/MethodLength:
 Layout/EmptyLineAfterMagicComment:
   Enabled: false
 
+Layout/FirstArrayElementIndentation:
+  EnforcedStyle: consistent
+
 Layout/LineLength:
   Max: 120
 


### PR DESCRIPTION
Change the rubocop array indentation:
https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/FirstArrayElementIndentation