### PR TITLE
Namespace Aware class_under_test helper

### DIFF
--- a/test/project_templates/sources/test_empty.rb
+++ b/test/project_templates/sources/test_empty.rb
@@ -7,7 +7,6 @@ class TestEmpty < MiniTest::Test
   attr_reader :source
 
   def setup
-    @class_under_test = ProjectTemplates::Sources::Empty
     @source = class_under_test.new
   end
 

--- a/test/project_templates/sources/test_env_file.rb
+++ b/test/project_templates/sources/test_env_file.rb
@@ -10,7 +10,6 @@ class TestEnvFile < MiniTest::Test
   attr_reader :json, :source
 
   def setup
-    @class_under_test = ProjectTemplates::Sources::EnvFile
     @source = mock_env(delete: "SOME_ENV") { class_under_test.new("SOME_ENV") }
   end
 

--- a/test/project_templates/sources/test_env_string.rb
+++ b/test/project_templates/sources/test_env_string.rb
@@ -9,7 +9,6 @@ class TestEnvString < MiniTest::Test
   attr_reader :json, :source
 
   def setup
-    @class_under_test = ProjectTemplates::Sources::EnvString
     @source = class_under_test.new("SOME_ENV")
   end
 

--- a/test/project_templates/sources/test_file.rb
+++ b/test/project_templates/sources/test_file.rb
@@ -10,7 +10,6 @@ class TestFile < MiniTest::Test
   attr_reader :json, :source
 
   def setup
-    @class_under_test = ProjectTemplates::Sources::File
     @source = class_under_test.new(file("valid.yaml", exist: true))
   end
 

--- a/test/project_templates/sources/test_string.rb
+++ b/test/project_templates/sources/test_string.rb
@@ -7,7 +7,6 @@ class TestString < MiniTest::Test
   attr_reader :json, :source
 
   def setup
-    @class_under_test = ProjectTemplates::Sources::String
     @json = { hello: "world" }.to_json
     @source = class_under_test.new(json)
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -15,14 +15,19 @@ module ClassUnderTest
   # `TestFoobar` to `ProjectTemplates::Foobar`. At least for the moment a more
   # complicated helper is not required, just "include it into your test file"
   # to make it available.
-  # TODO: make smarter: aware of namespaces. Walk up to test/ then prepend the
-  # default namespace, swap / with :: and to 'camelcase stuff'
   def class_under_test
     return @class_under_test if defined?(@class_under_test)
 
-    namespace = "ProjectTemplates"
-    test_name = self.class.to_s
-    full_class_name = [namespace, test_name[4..]].join("::")
+    class_name = self.class.name.to_sym
+    file = Pathname.new(Object.const_source_location(class_name).first)
+    base_path = Pathname.new(Dir.pwd)
+    relative = file.relative_path_from(base_path)
+
+    # This is a bad version of ActiveSupport tools for transforming strings to
+    # ruby classes, constants, namespaces, etc.
+    namespace = relative.dirname.to_s.split("/")[1..].map { _1.split("_").map(&:capitalize).join }.join("::")
+
+    full_class_name = [namespace, class_name.to_s[4..]].join("::")
     @class_under_test = Kernel.const_get(full_class_name)
   end
 end


### PR DESCRIPTION

### Improve the `class_under_test` test helper

This still isn't perfect, but it beats pulling active support for just
this little thing. It figures out what class a test maps back to. It
does that by assuming the name of a test maps to a class:

1. `/test/foo/bar/test_baz.rb` defines `TestBaz`
2. `TestBaz` is the tests for the `Baz` class.
3. `/lib/foo/bar/baz.rb` defines `Baz`

class_under_test looks at the class for the current test, backs up the
directory to the root of the project, does some directory math to figure
out the path to the current test file. Then it does some basic string
munging to try and make that path into what the probable namespaces are.
Finally, it mangles the test class in a way that it should match the
tested class and glues that to the end of the computed namespace.

If all this goes wrong you can always define `@class_under_test
= Foo::Bar:baz` in the test's setup block and that will be used instead