### PR TITLE
Build out ConfigPaths and ConfigVariables

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,6 +12,10 @@ Metrics/AbcSize:
   Exclude:
     - "test/**/*"
 
+Metrics/ClassLength:
+  Exclude:
+    - "test/**/*"
+
 Metrics/MethodLength:
   Exclude:
     - "test/**/*"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,6 +7,8 @@ AllCops:
   TargetRubyVersion: 3.1
 
 Metrics/AbcSize:
+  IgnoredMethods:
+    - initialize
   Exclude:
     - "test/**/*"
 

--- a/lib/project_templates.rb
+++ b/lib/project_templates.rb
@@ -14,6 +14,7 @@ require_relative "project_templates/sources/env_string"
 require_relative "project_templates/sources/env_file"
 require_relative "project_templates/config"
 require_relative "project_templates/config_paths"
+require_relative "project_templates/config_variables"
 require_relative "project_templates/version"
 
 module ProjectTemplates

--- a/lib/project_templates.rb
+++ b/lib/project_templates.rb
@@ -13,6 +13,7 @@ require_relative "project_templates/sources/string"
 require_relative "project_templates/sources/env_string"
 require_relative "project_templates/sources/env_file"
 require_relative "project_templates/config"
+require_relative "project_templates/config_paths"
 require_relative "project_templates/version"
 
 module ProjectTemplates

--- a/lib/project_templates/config.rb
+++ b/lib/project_templates/config.rb
@@ -59,7 +59,6 @@ module ProjectTemplates
     # template_path to produce project_path
     attr_accessor :project_name
 
-    # TODO: attr_accessor  :user_variables, :project_variables, :run_variables
     sig { returns(Dictionary) }
     # Global variables are read from a configuration file and will override
     # project variables when a conflict occurs. Global variables can in turn be

--- a/lib/project_templates/config_paths.rb
+++ b/lib/project_templates/config_paths.rb
@@ -9,7 +9,8 @@ module ProjectTemplates
   class ConfigPaths
     extend T::Sig
 
-    DEFAULT_TEMPLATE = T.let(Pathname.new("~/.share/project_templates/").expand_path, Pathname)
+    # TODO: Maybe these should be lambdas so they resolve at run time not parse time
+    DEFAULT_TEMPLATE = T.let(Pathname.new("~/.share/project_templates").expand_path, Pathname)
     DEFAULT_WORKING = T.let(Pathname.new(Dir.pwd).expand_path, Pathname)
 
     sig do
@@ -32,8 +33,8 @@ module ProjectTemplates
       @target_name = target_name
       @template = T.let(Pathname.new(template_path).expand_path, Pathname)
       @working = T.let(Pathname.new(working_path).expand_path, Pathname)
-      @project = T.let(Pathname.new(template).join(project_name).expand_path, Pathname)
-      @target = T.let(Pathname.new(working).join(target_name).expand_path, Pathname)
+      @project = T.let(@template.join(project_name).expand_path, Pathname)
+      @target = T.let(@working.join(target_name).expand_path, Pathname)
       @errors = T.let([], T::Array[String])
       valid?
     end
@@ -46,7 +47,7 @@ module ProjectTemplates
       @errors << "project path cannot be read" unless @project.readable?
       @errors << "working directory cannot be written" unless @working.writable?
       @errors << "target directory already exists" if @target.writable?
-      @errors.any?
+      @errors.empty?
     end
 
     sig { returns(T::Array[String]) }

--- a/lib/project_templates/config_paths.rb
+++ b/lib/project_templates/config_paths.rb
@@ -9,8 +9,8 @@ module ProjectTemplates
   class ConfigPaths
     extend T::Sig
 
-    DEFAULT_TEMPLATE = T.let(Pathname.new("~/.share/project_templates/").expand_path.to_s, String)
-    DEFAULT_WORKING = T.let(Pathname.new(Dir.pwd).expand_path.to_s, String)
+    DEFAULT_TEMPLATE = T.let(Pathname.new("~/.share/project_templates/").expand_path, Pathname)
+    DEFAULT_WORKING = T.let(Pathname.new(Dir.pwd).expand_path, Pathname)
 
     sig do
       params(
@@ -25,15 +25,15 @@ module ProjectTemplates
     def initialize(
       project_name:,
       target_name:,
-      template_path: DEFAULT_TEMPLATE,
-      working_path: DEFAULT_WORKING
+      template_path: DEFAULT_TEMPLATE.to_s,
+      working_path: DEFAULT_WORKING.to_s
     )
       @project_name = project_name
       @target_name = target_name
-      @template = Pathname.new(template_path || DEFAULT_TEMPLATE).expand_path
-      @working = Pathname.new(working_path || DEFAULT_WORKING).expand_path
-      @project = Pathname.new(template).join(project_name).expand_path
-      @target = Pathname.new(working).join(target_name).expand_path
+      @template = T.let(Pathname.new(template_path).expand_path, Pathname)
+      @working = T.let(Pathname.new(working_path).expand_path, Pathname)
+      @project = T.let(Pathname.new(template).join(project_name).expand_path, Pathname)
+      @target = T.let(Pathname.new(working).join(target_name).expand_path, Pathname)
       @errors = T.let([], T::Array[String])
       valid?
     end
@@ -42,14 +42,14 @@ module ProjectTemplates
     # are all the paths valid readable / writable locations?
     def valid?
       @errors.clear
-      @errors << ("template path cannot be read") unless @template.readable?
-      @errors << ("project path cannot be read") unless @project.readable?
-      @errors << ("working directory cannot be written to") unless @working.writable?
-      @errors << ("target directory already exists") if @target.writable?
+      @errors << "template path cannot be read" unless @template.readable?
+      @errors << "project path cannot be read" unless @project.readable?
+      @errors << "working directory cannot be written" unless @working.writable?
+      @errors << "target directory already exists" if @target.writable?
       @errors.any?
     end
 
-    sig { returns(T::Array(String)) }
+    sig { returns(T::Array[String]) }
     # Errors that happen after validation
     attr_reader :errors
 
@@ -68,7 +68,7 @@ module ProjectTemplates
     sig { returns(String) }
     # the path where the target for the project template will be built
     def working
-      @workign.to_s
+      @working.to_s
     end
 
     sig { returns(String) }

--- a/lib/project_templates/config_paths.rb
+++ b/lib/project_templates/config_paths.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+# typed: strict
+
+require "sorbet-runtime"
+
+module ProjectTemplates
+  # This is a wrapper class that contains pointers to all of the
+  # important paths used by the application.
+  class ConfigPaths
+    extend T::Sig
+
+    DEFAULT_TEMPLATE = T.let(Pathname.new("~/.share/project_templates/").expand_path.to_s, String)
+    DEFAULT_WORKING = T.let(Pathname.new(Dir.pwd).expand_path.to_s, String)
+
+    sig do
+      params(
+        project_name: String,
+        target_name: String,
+        template_path: String,
+        working_path: String
+      ).void
+    end
+    # initializes the paths used in the config. By default paths will be
+    # expanded. if a path is provided it will expanded to an absolute one.
+    def initialize(
+      project_name:,
+      target_name:,
+      template_path: DEFAULT_TEMPLATE,
+      working_path: DEFAULT_WORKING
+    )
+      @project_name = project_name
+      @target_name = target_name
+      @template = Pathname.new(template_path || DEFAULT_TEMPLATE).expand_path
+      @working = Pathname.new(working_path || DEFAULT_WORKING).expand_path
+      @project = Pathname.new(template).join(project_name).expand_path
+      @target = Pathname.new(working).join(target_name).expand_path
+      @errors = T.let([], T::Array[String])
+      valid?
+    end
+
+    sig { returns(T::Boolean) }
+    # are all the paths valid readable / writable locations?
+    def valid?
+      @errors.clear
+      @errors << ("template path cannot be read") unless @template.readable?
+      @errors << ("project path cannot be read") unless @project.readable?
+      @errors << ("working directory cannot be written to") unless @working.writable?
+      @errors << ("target directory already exists") if @target.writable?
+      @errors.any?
+    end
+
+    sig { returns(T::Array(String)) }
+    # Errors that happen after validation
+    attr_reader :errors
+
+    sig { returns(String) }
+    # that path where templates can be found
+    def template
+      @template.to_s
+    end
+
+    sig { returns(String) }
+    # the path to where the project template can be found
+    def project
+      @project.to_s
+    end
+
+    sig { returns(String) }
+    # the path where the target for the project template will be built
+    def working
+      @workign.to_s
+    end
+
+    sig { returns(String) }
+    # the path to where the project template will be built
+    def target
+      @target.to_s
+    end
+  end
+end

--- a/lib/project_templates/config_variables.rb
+++ b/lib/project_templates/config_variables.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+# typed: strict
+
+require "sorbet-runtime"
+
+module ProjectTemplates
+  # A wrapper class that considers multiple sources for variables
+  # and exposes the 'final computed result'.
+  class ConfigVariables
+    extend T::Sig
+  end
+end

--- a/lib/project_templates/config_variables.rb
+++ b/lib/project_templates/config_variables.rb
@@ -11,9 +11,9 @@ module ProjectTemplates
 
     sig do
       params(
-        project_variables: T.nilable(Dictionary),
-        global_variables: T.nilable(Dictionary),
-        run_variables: T.nilable(Dictionary)
+        project: T.nilable(Dictionary),
+        global: T.nilable(Dictionary),
+        run: T.nilable(Dictionary)
       ).void
     end
     # Pass in the three sets of variables and this will give you back a
@@ -22,14 +22,35 @@ module ProjectTemplates
     #   * global variables are less important than
     #   * run variables
     def initialize(
-      project_variables: nil,
-      global_variables: nil,
-      run_variables: nil
+      project: nil,
+      global: nil,
+      run: nil
     )
-      default_dictionary = DEFAULT_DICTIONARY_LOADER.new.load
-      @project_variables = project_variables || default_dictionary
-      @global_variables = global_variables || default_dictionary
-      @run_variables = run_variables || default_dictionary
+      default = Sources::Empty.new.load
+      @project = T.let(project || default, Dictionary)
+      @global = T.let(global || default, Dictionary)
+      @run = T.let(run || default, Dictionary)
+    end
+
+    sig { returns(Dictionary) }
+    # the lowest level variables
+    attr_accessor :project
+
+    sig { returns(Dictionary) }
+    # the medium level variables
+    attr_accessor :global
+
+    sig { returns(Dictionary) }
+    # the highest level variables
+    attr_accessor :run
+
+    sig { returns(Dictionary) }
+    # applies the overriding rules.
+    def dictionary
+      @dictionary ||= begin
+        dictionary_sum project.to_h.merge(global.to_h).merge(run.to_h)
+        Dictionary.new(dictionary_sum)
+      end
     end
   end
 end

--- a/lib/project_templates/config_variables.rb
+++ b/lib/project_templates/config_variables.rb
@@ -27,9 +27,10 @@ module ProjectTemplates
       run: nil
     )
       default = Sources::Empty.new.load
-      @project = T.let(project || default, Dictionary)
-      @global = T.let(global || default, Dictionary)
-      @run = T.let(run || default, Dictionary)
+      @project = T.let(T.must(project || default), Dictionary)
+      @global = T.let(T.must(global || default), Dictionary)
+      @run = T.let(T.must(run || default), Dictionary)
+      @dictionary = T.let(build_dictionary, Dictionary)
     end
 
     sig { returns(Dictionary) }
@@ -45,12 +46,17 @@ module ProjectTemplates
     attr_accessor :run
 
     sig { returns(Dictionary) }
-    # applies the overriding rules.
-    def dictionary
-      @dictionary ||= begin
-        dictionary_sum project.to_h.merge(global.to_h).merge(run.to_h)
-        Dictionary.new(dictionary_sum)
-      end
+    # the aggregate dictionary
+    attr_accessor :dictionary
+
+    private
+
+    sig { returns(Dictionary) }
+    # does the work of building a dictionary from run, project, and global variables
+    def build_dictionary
+      # pro glob run
+      @global.to_h.merge(@global.to_h)
+      @global
     end
   end
 end

--- a/lib/project_templates/config_variables.rb
+++ b/lib/project_templates/config_variables.rb
@@ -8,5 +8,28 @@ module ProjectTemplates
   # and exposes the 'final computed result'.
   class ConfigVariables
     extend T::Sig
+
+    sig do
+      params(
+        project_variables: T.nilable(Dictionary),
+        global_variables: T.nilable(Dictionary),
+        run_variables: T.nilable(Dictionary)
+      ).void
+    end
+    # Pass in the three sets of variables and this will give you back a
+    # dictionary with all of the overrides applied:
+    #   * project variables are less important than
+    #   * global variables are less important than
+    #   * run variables
+    def initialize(
+      project_variables: nil,
+      global_variables: nil,
+      run_variables: nil
+    )
+      default_dictionary = DEFAULT_DICTIONARY_LOADER.new.load
+      @project_variables = project_variables || default_dictionary
+      @global_variables = global_variables || default_dictionary
+      @run_variables = run_variables || default_dictionary
+    end
   end
 end

--- a/lib/project_templates/config_variables.rb
+++ b/lib/project_templates/config_variables.rb
@@ -54,9 +54,8 @@ module ProjectTemplates
     sig { returns(Dictionary) }
     # does the work of building a dictionary from run, project, and global variables
     def build_dictionary
-      # pro glob run
-      @global.to_h.merge(@global.to_h)
-      @global
+      merged_values = project.to_h.merge(global.to_h).merge(run.to_h)
+      Dictionary.load(merged_values.to_json)
     end
   end
 end

--- a/lib/project_templates/dictionary.rb
+++ b/lib/project_templates/dictionary.rb
@@ -16,6 +16,7 @@ module ProjectTemplates
   # can always call `.table` on a key to get it's value as a hash with
   # symbolized keys.
   class Dictionary < SimpleDelegator
+    extend T::Sig
     # New is made private to ensure only a valid `OpenStruct` is passed to the class
     # constructor and delegation works as expected.
     private_class_method :new
@@ -42,6 +43,15 @@ module ProjectTemplates
       end
 
       alias parse load
+    end
+
+    sig { returns(T::Hash[Symbol, T.untyped]) }
+    # converts the dictionary into a ruby hash with symbolized keys. Values are
+    # either int, float, bool, hash, array but to avoid a nightmare of sorbet
+    # config I'm just going to say it's untyped
+    def to_h
+      t = ->(v) { v.is_a?(OpenStruct) ? v.table.transform_values { t[_1] } : v }
+      t[@delegate_sd_obj]
     end
   end
 end

--- a/lib/project_templates/dictionary.rb
+++ b/lib/project_templates/dictionary.rb
@@ -36,11 +36,13 @@ module ProjectTemplates
       # parser to produce an `OpenStruct` then everything is fine. Some valid JSON
       # and YAML will not produce a dictionary. E.g. "[1, 2, 3]" is valid for
       # both JSON and YAML but parses to an `Array`. Invalid JSON will also cause
-      # an error. If a valid `OpenStruct` cannot be formed `ArgumentError` is raised.
+      # an error. If a valid `apenStruct` cannot be formed `ArgumentError` is raised.
       def load(input)
         yaml_input = YAML.safe_load(input)
         json_input = yaml_input.to_json
         new(json_input)
+      rescue Psych::Exception => e
+        raise(ArgumentError, e.to_s)
       end
     end
 
@@ -58,13 +60,7 @@ module ProjectTemplates
       @struct.respond_to?(method) || super
     end
 
-    sig do
-      params(
-        method: T.any(String, Symbol),
-        _args: T.nilable(T::Array[T.untyped]),
-        _block: T.nilable(T.proc.void)
-      ).returns(T.untyped)
-    end
+    sig { params(method: T.any(String, Symbol), _args: T.untyped, _block: T.untyped).returns(T.untyped) }
     def method_missing(method, *_args, &_block)
       @struct.respond_to?(method) ? @struct.send(method) : super
     end

--- a/lib/project_templates/dictionary_source.rb
+++ b/lib/project_templates/dictionary_source.rb
@@ -35,7 +35,7 @@ module ProjectTemplates
       !dictionary.eql?(nil)
     end
 
-    sig { void }
+    sig { T.nilable(Dictionary) }
     # if loadable, try to create a dictionary from from the source
     def load
       @dictionary = load_source if loadable? && !loaded?

--- a/lib/project_templates/dictionary_source.rb
+++ b/lib/project_templates/dictionary_source.rb
@@ -35,7 +35,7 @@ module ProjectTemplates
       !dictionary.eql?(nil)
     end
 
-    sig { T.nilable(Dictionary) }
+    sig { returns(T.nilable(Dictionary)) }
     # if loadable, try to create a dictionary from from the source
     def load
       @dictionary = load_source if loadable? && !loaded?

--- a/test/project_templates/test_config.rb
+++ b/test/project_templates/test_config.rb
@@ -48,6 +48,7 @@ class TestConfig < MiniTest::Test
   end
 
   def test_initialize_can_be_provided_all_arguments
+    # mocking and #== don't play well together
     args = {
       dry_run: true,
       template_path: Pathname.new("/").expand_path,
@@ -56,13 +57,13 @@ class TestConfig < MiniTest::Test
       working_path: Pathname.new("/").expand_path,
       project_name: "new_project",
       target_name: "some_target",
-      project_variables: Minitest::Mock.new(ProjectTemplates::Dictionary.load("{}")),
-      global_variables: Minitest::Mock.new(ProjectTemplates::Dictionary.load("{}")),
-      run_variables: Minitest::Mock.new(ProjectTemplates::Dictionary.load("{}")),
+      project_variables: ProjectTemplates::Dictionary.load("{}"),
+      global_variables: ProjectTemplates::Dictionary.load("{}"),
+      run_variables: ProjectTemplates::Dictionary.load("{}"),
     }
-    # TODO: inited_config = class_under_test.new(**args)
+    inited_config = class_under_test.new(**args)
     args.each do |argument, expected_value|
-      # TODO: assert_equal expected_value, inited_config.send(argument)
+      assert_equal expected_value, inited_config.send(argument)
     end
   end
 end

--- a/test/project_templates/test_config.rb
+++ b/test/project_templates/test_config.rb
@@ -60,9 +60,9 @@ class TestConfig < MiniTest::Test
       global_variables: Minitest::Mock.new(ProjectTemplates::Dictionary.load("{}")),
       run_variables: Minitest::Mock.new(ProjectTemplates::Dictionary.load("{}")),
     }
-    inited_config = class_under_test.new(**args)
+    # TODO: inited_config = class_under_test.new(**args)
     args.each do |argument, expected_value|
-      assert_equal expected_value, inited_config.send(argument)
+      # TODO: assert_equal expected_value, inited_config.send(argument)
     end
   end
 end

--- a/test/project_templates/test_config_paths.rb
+++ b/test/project_templates/test_config_paths.rb
@@ -2,13 +2,13 @@
 
 require "test_helper"
 
-class TestConfigVariables < MiniTest::Test
+class TestConfigPaths < MiniTest::Test
   extend HasAttributeHelper
   include ClassUnderTest
 
-  attr_reader :vars
+  attr_reader :paths
 
   def setup
-    @vars = class_under_test.new
+    @paths = class_under_test.new
   end
 end

--- a/test/project_templates/test_config_paths.rb
+++ b/test/project_templates/test_config_paths.rb
@@ -9,26 +9,155 @@ class TestConfigPaths < MiniTest::Test
   attr_reader :paths
 
   def setup
-    @paths = class_under_test.new
+    @paths = class_under_test.new(
+      target_name: "target",
+      project_name: "project"
+    )
   end
 
-  # has readers for
-  # errors, template, working, project, target
+  test_has_attribute(:paths, :errors, readable: true)
+  test_has_attribute(:paths, :project, readable: true)
+  test_has_attribute(:paths, :target, readable: true)
+  test_has_attribute(:paths, :template, readable: true)
+  test_has_attribute(:paths, :valid, interrogatable: true)
+  test_has_attribute(:paths, :working, readable: true)
 
-  # default working is sane
-  # default target is sane
+  def test_defines_default_constants
+    assert_equal(Pathname.new("~/.share/project_templates").expand_path.to_s, class_under_test::DEFAULT_TEMPLATE.to_s)
+    assert_equal(Pathname.new(Dir.pwd).expand_path.to_s, class_under_test::DEFAULT_WORKING.to_s)
+  end
 
-  # has valid? that verifies things:
-  # * template path is not readable
-  # * project path is not readable
-  # * working directory not writable
-  # * target path exists
+  def test_init_uses_defaults_with_provided_args
+    assert_equal(Pathname.new("~/.share/project_templates").expand_path.to_s, paths.template)
+    assert_equal(Pathname.new("~/.share/project_templates/project").expand_path.to_s, paths.project)
+    assert_equal(Pathname.new(Dir.pwd).expand_path.to_s, paths.working)
+    assert_equal(Pathname.new(Dir.pwd).join("./target").expand_path.to_s, paths.target)
+  end
 
-  # init takes project name, target name, working dir and templates dir
-  # init defaults are from defaults consts
+  def test_init_allows_override_of_default_paths
+    paths_init = class_under_test.new(
+      project_name: "project",
+      target_name: "target",
+      template_path: "/templates",
+      working_path: "/src"
+    )
+    assert_equal("/templates", paths_init.template)
+    assert_equal("/templates/project", paths_init.project)
+    assert_equal("/src/target", paths_init.target)
+    assert_equal("/src", paths_init.working)
+  end
 
-  # init computes target and project dir
+  def test_erorrs_starts_empty
+    dir("/templates/project") do
+      paths_init = class_under_test.new(
+        template_path: Pathname.new(Dir.pwd).join("./templates").to_s,
+        project_name: "project",
+        target_name: "target"
+      )
+      assert_predicate(paths_init.errors, :empty?)
+      assert_predicate(paths_init, :valid?)
+    end
+  end
 
-  # allow override of target dir
-  # allow override of project dir
+  def test_allows_explicit_customization_of_project_dir
+    # TODO: make an attr_writer for project
+    skip "not yet implemented"
+    dir("/templates/custom_project", "/templates/project") do
+      paths_init = class_under_test.new(
+        template_path: Pathname.new(Dir.pwd).join("./templates").expand_path.to_s,
+        project_name: "project",
+        target_name: "target"
+      )
+      paths_init.project = template.join("./custom_project").to_s
+      assert_predicate(paths_init, :valid?)
+    end
+  end
+
+  def test_allows_explicit_customization_of_target_dir
+    # TODO: make an attr_writer for target
+    skip "not yet implemented"
+    dir("/templates/project") do
+      paths_init = class_under_test.new(
+        template_path: Pathname.new(Dir.pwd).join("./templates").expand_path.to_s,
+        project_name: "project",
+        target_name: "target"
+      )
+      paths_init.target = Pathname.new(Dir.pwd).join("./foo/bar/baz").expand_path
+      assert_predicate(paths_init, :valid?)
+    end
+  end
+
+  def test_allows_explicit_customization_of_working_dir
+    # TODO: make an attr_writer for working
+    skip "not yet implemented"
+    dir("/templates/project") do
+      paths_init = class_under_test.new(
+        template_path: Pathname.new(Dir.pwd).join("./templates").expand_path.to_s,
+        project_name: "project",
+        target_name: "target"
+      )
+      paths_init.working = Pathname.new(Dir.pwd).join("./foo/bar/baz").expand_path
+      assert_predicate(paths_init, :valid?)
+    end
+  end
+
+  def test_valid_fails_on_missing_template_directiory
+    dir("/templates/project") do
+      paths_init = class_under_test.new(
+        template_path: Pathname.new(Dir.pwd).join("./not_exist").to_s,
+        project_name: "project",
+        target_name: "target"
+      )
+      assert_includes(paths_init.errors, "template path cannot be read")
+    end
+  end
+
+  def test_valid_fails_on_unreadable_project_directiory
+    dir("/templates/project") do
+      paths_init = class_under_test.new(
+        template_path: Pathname.new(Dir.pwd).to_s,
+        project_name: "not_exist",
+        target_name: "target"
+      )
+      assert_includes(paths_init.errors, "project path cannot be read")
+    end
+  end
+
+  def test_valid_fails_on_existing_target_directiory
+    dir("/templates/project", "/target") do
+      paths_init = class_under_test.new(
+        template_path: Pathname.new(Dir.pwd).join("./templates").to_s,
+        working_path: Pathname.new(Dir.pwd).to_s,
+        project_name: "project",
+        target_name: "target"
+      )
+      assert_includes(paths_init.errors, "target directory already exists")
+    end
+  end
+
+  def test_valid_fails_on_unwritable_working_directiory
+    dir("/templates/project", "/projects") do
+      working_path = Pathname.new(Dir.pwd).join("./projects")
+      working_path.lchmod(0o544)
+      paths_init = class_under_test.new(
+        template_path: Pathname.new(Dir.pwd).join("./templates").to_s,
+        working_path: working_path.to_s,
+        project_name: "project",
+        target_name: "target"
+      )
+      assert_includes(paths_init.errors, "working directory cannot be written")
+      working_path.lchmod(0o744)
+    end
+  end
+
+  private
+
+  def dir(*paths, &block)
+    Dir.mktmpdir do |dir|
+      Dir.chdir dir do
+        paths.each { Pathname.new(Dir.pwd).join(".#{_1}").mkpath }
+        yield(block)
+      end
+    end
+  end
 end

--- a/test/project_templates/test_config_paths.rb
+++ b/test/project_templates/test_config_paths.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TestConfigVariables < MiniTest::Test
+  extend HasAttributeHelper
+  include ClassUnderTest
+
+  attr_reader :vars
+
+  def setup
+    @vars = class_under_test.new
+  end
+end

--- a/test/project_templates/test_config_paths.rb
+++ b/test/project_templates/test_config_paths.rb
@@ -11,4 +11,24 @@ class TestConfigPaths < MiniTest::Test
   def setup
     @paths = class_under_test.new
   end
+
+  # has readers for
+  # errors, template, working, project, target
+
+  # default working is sane
+  # default target is sane
+
+  # has valid? that verifies things:
+  # * template path is not readable
+  # * project path is not readable
+  # * working directory not writable
+  # * target path exists
+
+  # init takes project name, target name, working dir and templates dir
+  # init defaults are from defaults consts
+
+  # init computes target and project dir
+
+  # allow override of target dir
+  # allow override of project dir
 end

--- a/test/project_templates/test_config_variables.rb
+++ b/test/project_templates/test_config_variables.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TestConfigVariables < MiniTest::Test
+  extend HasAttributeHelper
+  include ClassUnderTest
+
+  attr_reader :vars
+
+  def setup
+    @vars = class_under_test.new
+  end
+end

--- a/test/project_templates/test_config_variables.rb
+++ b/test/project_templates/test_config_variables.rb
@@ -11,4 +11,11 @@ class TestConfigVariables < MiniTest::Test
   def setup
     @vars = class_under_test.new
   end
+
+  # has reader for project global run and dictionary
+  # init takes project global and run
+  # init defaults are empty dictionaries
+  # dictionary has global override project
+  # dictionary has run override global
+  # dictionary has run override project
 end

--- a/test/project_templates/test_config_variables.rb
+++ b/test/project_templates/test_config_variables.rb
@@ -12,10 +12,42 @@ class TestConfigVariables < MiniTest::Test
     @vars = class_under_test.new
   end
 
-  # has reader for project global run and dictionary
-  # init takes project global and run
-  # init defaults are empty dictionaries
-  # dictionary has global override project
-  # dictionary has run override global
-  # dictionary has run override project
+  test_has_attribute(:vars, :dictionary, readable: true)
+  test_has_attribute(:vars, :global, readable: true)
+  test_has_attribute(:vars, :project, readable: true)
+  test_has_attribute(:vars, :run, readable: true)
+
+  def test_initializes_with_empty_dictionaries
+    assert_equal({}, vars.global.to_h)
+    assert_equal({}, vars.project.to_h)
+    assert_equal({}, vars.run.to_h)
+  end
+
+  def test_initializes_with_provided_dictionaries
+    vars_init = class_under_test.new(
+      global: dict(foo: 1),
+      project: dict(foo: 2),
+      run: dict(foo: 3)
+    )
+    assert_equal({ foo: 1 }, vars_init.global.to_h)
+    assert_equal({ foo: 2 }, vars_init.project.to_h)
+    assert_equal({ foo: 3 }, vars_init.run.to_h)
+  end
+
+  def test_dictionary_overrides_project_with_global_and_global_with_run
+    vars_dict = class_under_test.new(
+      global: dict(bar: 2, baz: 2),
+      project: dict(foo: 1, bar: 1, baz: 1),
+      run: dict(baz: 3)
+    ).dictionary
+    assert_equal(1, vars_dict.foo)
+    assert_equal(2, vars_dict.bar)
+    assert_equal(3, vars_dict.baz)
+  end
+
+  private
+
+  def dict(**values)
+    ProjectTemplates::Dictionary.load(values.to_json)
+  end
 end

--- a/test/project_templates/test_dictionary.rb
+++ b/test/project_templates/test_dictionary.rb
@@ -10,20 +10,33 @@ class TestDictionary < Minitest::Test
       ---
       foo: 123
     YAML
-    dict = class_under_test.load(input)
-    assert_equal 123, dict.foo
+    class_under_test.load(input)
   end
 
   def test_loads_with_json
     input = '{"foo": 123}'
-    dict = class_under_test.load(input)
-    assert_equal 123, dict.foo
+    class_under_test.load(input)
   end
 
-  def test_parse_is_another_spelling_of_load
-    input = { foo: 123 }.to_json
-    dict = class_under_test.parse(input)
-    assert_equal 123, dict.foo
+  def test_implements_method_missing
+    input = '{"foo": 123}'
+    dict = class_under_test.new(input)
+    assert_equal(123, dict.foo)
+    assert_raises(NoMethodError) { dict.bar }
+  end
+
+  def test_implemements_respond_to_missing
+    input = '{"foo": 123}'
+    dict = class_under_test.new(input)
+    assert(dict.respond_to?(:foo))
+    refute(dict.respond_to?(:bar))
+    assert_instance_of(Method, dict.method(:foo))
+    assert_raises(NameError) { dict.method(:bar) }
+  end
+
+  def test_initializes_with_json
+    input = '{"foo": 123}'
+    class_under_test.new(input)
   end
 
   def test_nested_keys_in_yaml
@@ -41,25 +54,24 @@ class TestDictionary < Minitest::Test
     assert_raises(NoMethodError) { dict.baz }
   end
 
-  def test_new_is_private
-    assert_raises(NoMethodError) { class_under_test.new }
-  end
-
   def test_throws_argument_error_on_yaml_that_doesnt_make_a_hash
     input = <<~YAML
       ---
       - foo
     YAML
     assert_raises(ArgumentError) { class_under_test.load(input) }
+    assert_raises(ArgumentError) { class_under_test.new(input) }
   end
 
   def test_throws_argument_error_on_json_that_doesnt_make_a_hash
     input = "[1, 2, 3]"
     assert_raises(ArgumentError) { class_under_test.load(input) }
+    assert_raises(ArgumentError) { class_under_test.new(input) }
   end
 
   def test_throws_argument_error_on_invalid_json
     input = "{invalid"
     assert_raises(ArgumentError) { class_under_test.load(input) }
+    assert_raises(ArgumentError) { class_under_test.new(input) }
   end
 end

--- a/test/project_templates/test_dictionary_loader.rb
+++ b/test/project_templates/test_dictionary_loader.rb
@@ -61,7 +61,8 @@ class TestDictionaryLoader < Minitest::Test
     source1.expect(:loaded?, false)
     source1.expect(:dictionary, nil)
 
-    dictionary = Minitest::Mock.new(ProjectTemplates::Dictionary.load({ foo: :bar }.to_json))
+    # can't be mocked because minitest doesn't do #==
+    dictionary = ProjectTemplates::Dictionary.load({ foo: :bar }.to_json)
     source2 = Minitest::Mock.new(ProjectTemplates::Sources::Empty.new)
     source2.expect(:loadable?, true)
     source2.expect(:loaded?, true)
@@ -72,7 +73,7 @@ class TestDictionaryLoader < Minitest::Test
 
     assert_predicate(loader_test, :loaded?)
     assert_equal(source2.object_id, loader_test.loaded_source.object_id)
-    # TODO: assert_equal(dictionary, loader_test.dictionary)
+    assert_equal(dictionary, loader_test.dictionary)
   end
 
   def test_loaded_source_is_nil_if_no_source_loads
@@ -110,7 +111,8 @@ class TestDictionaryLoader < Minitest::Test
   end
 
   def test_dicionary_is_loaded_sources_dictionary
-    dictionary = Minitest::Mock.new(ProjectTemplates::Dictionary.load({ foo: :bar }.to_json))
+    # can't be mocked because minitest doesn't do #==
+    dictionary = ProjectTemplates::Dictionary.load({ foo: :bar }.to_json)
     source = Minitest::Mock.new(ProjectTemplates::Sources::Empty.new)
     source.expect(:loadable?, true)
     source.expect(:dictionary, dictionary)
@@ -118,6 +120,6 @@ class TestDictionaryLoader < Minitest::Test
     loader_test = class_under_test.new(source)
     loader_test.load
 
-    # TODO: assert_equal(dictionary, loader_test.dictionary)
+    assert_equal(dictionary, loader_test.dictionary)
   end
 end

--- a/test/project_templates/test_dictionary_loader.rb
+++ b/test/project_templates/test_dictionary_loader.rb
@@ -72,7 +72,7 @@ class TestDictionaryLoader < Minitest::Test
 
     assert_predicate(loader_test, :loaded?)
     assert_equal(source2.object_id, loader_test.loaded_source.object_id)
-    assert_equal(dictionary, loader_test.dictionary)
+    # TODO: assert_equal(dictionary, loader_test.dictionary)
   end
 
   def test_loaded_source_is_nil_if_no_source_loads
@@ -118,6 +118,6 @@ class TestDictionaryLoader < Minitest::Test
     loader_test = class_under_test.new(source)
     loader_test.load
 
-    assert_equal(dictionary, loader_test.dictionary)
+    # TODO: assert_equal(dictionary, loader_test.dictionary)
   end
 end

--- a/test/project_templates/test_dictionary_source.rb
+++ b/test/project_templates/test_dictionary_source.rb
@@ -80,8 +80,8 @@ class TestDictionarySource < MiniTest::Test
     loader = Minitest::Mock.new.expect(:load!, true)
     source.define_singleton_method(:loadable?) { true }
     source.define_singleton_method(:load_source) { loader.load! }
-    source.load
-    loader.verify
+    # TODO: source.load
+    # TODO loader.verify
   end
 
   def test_load_source_not_called_if_not_loadable
@@ -89,7 +89,7 @@ class TestDictionarySource < MiniTest::Test
     source.define_singleton_method(:load_source) do
       raise(MethodError, "unloadable source should not call load_source")
     end
-    assert(source.load)
+    # TODO: assert(source.load)
   end
 
   def test_load_source_not_called_if_loaded

--- a/test/project_templates/test_dictionary_source.rb
+++ b/test/project_templates/test_dictionary_source.rb
@@ -77,11 +77,12 @@ class TestDictionarySource < MiniTest::Test
   end
 
   def test_load_source_called_if_loadable
-    loader = Minitest::Mock.new.expect(:load!, true)
+    dictionary = Minitest::Mock.new(ProjectTemplates::Dictionary.new("{}"))
+    loader = Minitest::Mock.new.expect(:load!, dictionary)
     source.define_singleton_method(:loadable?) { true }
     source.define_singleton_method(:load_source) { loader.load! }
-    # TODO: source.load
-    # TODO loader.verify
+    source.load
+    loader.verify
   end
 
   def test_load_source_not_called_if_not_loadable
@@ -89,7 +90,7 @@ class TestDictionarySource < MiniTest::Test
     source.define_singleton_method(:load_source) do
       raise(MethodError, "unloadable source should not call load_source")
     end
-    # TODO: assert(source.load)
+    refute(source.load)
   end
 
   def test_load_source_not_called_if_loaded


### PR DESCRIPTION
Still more work on https://github.com/cutehax0r/project_templates/issues/7

The `Config` object has a lot of accessors and the initializer is pretty
complicated. Let's group all of the paths together in a sub-objects so
that `Config.paths` can be meaningful. This object will compute (or
allow you to explicitly set) paths that will be used for writing out a
new project from a template.

It also does basic validation to ensure everything can be used.

A similar trick is pulled for the Variables. It takes in global, project, and run-time
configured variables and shares the "computed" total in an easy to access way.
It handles overrides gracefully.

### Tidy up dictionaries.

Testing with these was a bit of a pain. Changed from simple delegator to just a regular method_missing implementation. This also greatly 'degrossified' computing the 'final' variables dictionary from several smaller ones in `ConfigVariables`.

### Dictionary Loader improvements
The `load` method now returns the dictionary. It's just convenient to be able to call `Sources::String("...").load` and get a usable dictionary out of it.

### Other stuff
- some minor changes to rubocop rules: tests can be > 100 lines, init methods can assign many variables.