### PR TITLE
Modify Config to use New Namespaced Approach

### DIFF
--- a/exe/project_templates
+++ b/exe/project_templates
@@ -5,6 +5,13 @@
 require "project_templates"
 require "sorbet-runtime"
 
-config = ProjectTemplates::Config.new(dry_run: true)
-app = ProjectTemplates::App.new(config)
-app.run
+module ProjectTemplates
+  project = "foo"
+  target = "bar"
+  variables = ConfigVariables.new
+  paths = ConfigPaths.new(project_name: project, target_name: target)
+  config = ProjectTemplates::Config.new(project:, target:, variables:, paths:)
+
+  app = App.new(config)
+  app.run
+end

--- a/lib/project_templates/config.rb
+++ b/lib/project_templates/config.rb
@@ -12,112 +12,45 @@ module ProjectTemplates
   class Config
     extend T::Sig
 
-    DEFAULT_TEMPLATE_PATH = T.let(Pathname.new("~").expand_path, Pathname)
-    DEFAULT_PROJECT_PATH = T.let(Pathname.new("~").expand_path, Pathname)
-    DEFAULT_TARGET_PATH = T.let(Pathname.new(Dir.pwd).expand_path, Pathname)
-    DEFAULT_WORKING_PATH = T.let(Pathname.new(Dir.pwd).expand_path, Pathname)
-    DEFAULT_TARGET_NAME = T.let("target", String)
-    DEFAULT_PROJECT_NAME = T.let("project", String)
-    DEFAULT_DICTIONARY = T.let(Dictionary.load("{}"), Dictionary)
-
-    sig { returns(T::Boolean) }
-    # When dry-run is true no changes to the file system will be made but
-    # all other steps will be completed. Access to the target path will be
-    # verified and all other compilation steps will complete.
-    attr_accessor :dry_run
-    alias dry_run? dry_run
-
-    sig { returns(Pathname) }
-    # The path where template projects are located. This is the path where
-    # the project_path is expected to be
-    attr_accessor :template_path
-
-    sig { returns(Pathname) }
-    # The path which will be used as the "source" for creating the new project
-    # by default this would be located within #template_path and is computed by
-    # joining project_name to template_path.
-    attr_accessor :project_path
-
-    sig { returns(Pathname) }
-    # The path which will be created by copying files from the project_path to
-    # this location. The is computed by appending target_name to the current
-    # working directory
-    attr_accessor :target_path
-
-    sig { returns(Pathname) }
-    # The working directory, where the new project will be created. Defaults to
-    # the current working directory.
-    attr_accessor :working_path
+    sig { returns(String) }
+    # name of the template to use
+    attr_accessor :project
 
     sig { returns(String) }
-    # The name of the target. Appended to the end of working directory to form
-    # target_path.
-    attr_accessor :target_name
+    # name of the new templated project
+    attr_accessor :target
 
-    sig { returns(String) }
-    # the name of the project directory to use as a source. Appended to
-    # template_path to produce project_path
-    attr_accessor :project_name
+    sig { returns(ConfigVariables) }
+    # a container for all of the variable sets
+    attr_accessor :variables
 
-    sig { returns(Dictionary) }
-    # Global variables are read from a configuration file and will override
-    # project variables when a conflict occurs. Global variables can in turn be
-    # overridden by variables provided at 'run'.
-    attr_accessor :global_variables
-
-    sig { returns(Dictionary) }
-    # These are variables defined within the project template. They are the
-    # lowest level of priority so that you can override variables (e.g. email,
-    # copyright holder) by defining them globally once instead of needing to
-    # pass overrides on every invocation as command line arguments.
-    attr_accessor :project_variables
-
-    sig { returns(Dictionary) }
-    # Run variables are the most-specific variables. They override variables
-    # defined globally which have in turn overriden variables provided by a
-    # project.
-    attr_accessor :run_variables
+    sig { returns(ConfigPaths) }
+    # a container holding all the important paths
+    attr_accessor :paths
 
     sig do
       params(
-        dry_run: T::Boolean,
-        template_path: Pathname,
-        project_path: Pathname,
-        target_path: Pathname,
-        working_path: Pathname,
-        project_name: String,
-        target_name: String,
-        project_variables: Dictionary,
-        global_variables: Dictionary,
-        run_variables: Dictionary
+        project: String,
+        target: String,
+        paths: ConfigPaths,
+        variables: ConfigVariables
       ).void
     end
     # Initialize a config by explicitly setting all of the values. If you
     # don't want to set all values consider using one of the class methods
     # instead. Paths and Variables should probably become objects but for
     # now the rubocop rule about param lists will be ignored
-    def initialize( # rubocop:disable Metrics/ParameterLists
-      dry_run: false,
-      template_path: DEFAULT_TEMPLATE_PATH,
-      project_path: DEFAULT_PROJECT_PATH,
-      target_path: DEFAULT_TARGET_PATH,
-      working_path: DEFAULT_TARGET_PATH,
-      project_name: DEFAULT_PROJECT_NAME,
-      target_name: DEFAULT_TARGET_NAME,
-      project_variables: DEFAULT_DICTIONARY,
-      global_variables: DEFAULT_DICTIONARY,
-      run_variables: DEFAULT_DICTIONARY
-    )
-      @dry_run = dry_run
-      @template_path = template_path
-      @project_path = project_path
-      @target_path = target_path
-      @working_path = working_path
-      @project_name = project_name
-      @target_name = target_name
-      @project_variables = project_variables
-      @global_variables = global_variables
-      @run_variables = run_variables
+    def initialize(project:, target:, paths:, variables:)
+      @project = project
+      @target = target
+      @paths = paths
+      @variables = variables
+    end
+
+    sig { returns(Dictionary) }
+    # expose the computed dictionary of variables at a convenient location
+    def vars
+      variables.dictionary
     end
   end
 end

--- a/test/project_templates/test_app.rb
+++ b/test/project_templates/test_app.rb
@@ -7,16 +7,17 @@ class TestApp < MiniTest::Test
   attr_reader :app
 
   def setup
-    @app = class_under_test.new(MiniTest::Mock.new(ProjectTemplates::Config.new))
+    config = ProjectTemplates::Config.new(
+      project: "foo",
+      target: "bar",
+      variables: ProjectTemplates::ConfigVariables.new,
+      paths: ProjectTemplates::ConfigPaths.new(project_name: "foo", target_name: "bar")
+    )
+    @app = class_under_test.new(config)
   end
 
   def test_can_be_run
     assert_respond_to(app, :run)
-  end
-
-  def test_can_be_initialized_with_a_config
-    config = MiniTest::Mock.new(ProjectTemplates::Config.new)
-    class_under_test.new(config)
   end
 
   def test_prints_hello

--- a/test/project_templates/test_config.rb
+++ b/test/project_templates/test_config.rb
@@ -6,64 +6,30 @@ class TestConfig < MiniTest::Test
   extend HasAttributeHelper
   include ClassUnderTest
 
-  attr_reader :config
+  attr_reader :args, :config
 
   def setup
-    @config = class_under_test.new
+    @args = {
+      project: "project",
+      target: "target",
+      variables: ProjectTemplates::ConfigVariables.new,
+      paths: ProjectTemplates::ConfigPaths.new(project_name: "project", target_name: "target"),
+    }
+
+    @config = class_under_test.new(**args)
   end
 
-  test_has_attribute(:config, :dry_run, readable: true, writable: true, interrogatable: true)
-  test_has_attribute(:config, :template_path, readable: true, writable: true)
-  test_has_attribute(:config, :project_path, readable: true, writable: true)
-  test_has_attribute(:config, :target_path, readable: true, writable: true)
-  test_has_attribute(:config, :working_path, readable: true, writable: true)
-  test_has_attribute(:config, :project_name, readable: true, writable: true)
-  test_has_attribute(:config, :target_name, readable: true, writable: true)
-  test_has_attribute(:config, :project_variables, readable: true, writable: true)
-  test_has_attribute(:config, :global_variables, readable: true, writable: true)
-  test_has_attribute(:config, :run_variables, readable: true, writable: true)
+  test_has_attribute(:config, :project, readable: true, writable: true)
+  test_has_attribute(:config, :target, readable: true, writable: true)
+  test_has_attribute(:config, :paths, readable: true, writable: true)
+  test_has_attribute(:config, :variables, readable: true, writable: true)
 
-  def test_defines_default_constants
-    assert_equal(Pathname.new("~").expand_path, class_under_test::DEFAULT_TEMPLATE_PATH)
-    assert_equal(Pathname.new("~").expand_path, class_under_test::DEFAULT_PROJECT_PATH)
-    assert_equal(Pathname.new(Dir.pwd).expand_path, class_under_test::DEFAULT_TARGET_PATH)
-    assert_equal(Pathname.new(Dir.pwd).expand_path, class_under_test::DEFAULT_WORKING_PATH)
-    assert_equal("target", class_under_test::DEFAULT_TARGET_NAME)
-    assert_equal("project", class_under_test::DEFAULT_PROJECT_NAME)
-    assert_instance_of(ProjectTemplates::Dictionary, class_under_test::DEFAULT_DICTIONARY)
-    assert_predicate(class_under_test::DEFAULT_DICTIONARY.table, :empty?)
-  end
-
-  def test_initialize_uses_defaults
-    refute(config.dry_run?)
-    assert_equal(class_under_test::DEFAULT_TEMPLATE_PATH, config.template_path)
-    assert_equal(class_under_test::DEFAULT_PROJECT_PATH, config.project_path)
-    assert_equal(class_under_test::DEFAULT_TARGET_PATH, config.target_path)
-    assert_equal(class_under_test::DEFAULT_WORKING_PATH, config.working_path)
-    assert_equal("project", config.project_name)
-    assert_equal("target", config.target_name)
-    assert_equal(class_under_test::DEFAULT_DICTIONARY, config.project_variables)
-    assert_equal(class_under_test::DEFAULT_DICTIONARY, config.global_variables)
-    assert_equal(class_under_test::DEFAULT_DICTIONARY, config.run_variables)
-  end
+  # vars maps to variables.dictionary
 
   def test_initialize_can_be_provided_all_arguments
     # mocking and #== don't play well together
-    args = {
-      dry_run: true,
-      template_path: Pathname.new("/").expand_path,
-      project_path: Pathname.new("/").expand_path,
-      target_path: Pathname.new("/").expand_path,
-      working_path: Pathname.new("/").expand_path,
-      project_name: "new_project",
-      target_name: "some_target",
-      project_variables: ProjectTemplates::Dictionary.load("{}"),
-      global_variables: ProjectTemplates::Dictionary.load("{}"),
-      run_variables: ProjectTemplates::Dictionary.load("{}"),
-    }
-    inited_config = class_under_test.new(**args)
     args.each do |argument, expected_value|
-      assert_equal expected_value, inited_config.send(argument)
+      assert_equal expected_value, config.send(argument)
     end
   end
 end


### PR DESCRIPTION
Final PR for this, for now:
https://github.com/cutehax0r/project_templates/issues/7

### New Config setup

In a previous PR we made ConfigVariables and ConfigPaths work as
wrappers around configuration options. Now we're modifying Config to use
these new classes. Things are simpler now.